### PR TITLE
fix: Resolve hardcoded padding issue (Issue #5)

### DIFF
--- a/batcher.py
+++ b/batcher.py
@@ -48,7 +48,7 @@ class Batcher(umbridge.Model):
                             raise RuntimeError("Cannot pad an empty batch - no parameters available for shape inference")
 
                         while len(self.parameters) < self._batchsize:
-                            self.parameters.append(padding_vector)
+                            self.parameters.append(list(padding_vector))
                         self._compute()
                         self.batchLock.notify_all()
                         break
@@ -113,10 +113,10 @@ class Batcher(umbridge.Model):
         self.lock = threading.Lock()
 
     def get_input_sizes(self, config):
-        return [self.simulator.get_input_sizes(config)[0]] #Isn't this just the batch size? -> No
+        return [self.simulator.get_input_sizes(config)[0]]
 
     def get_output_sizes(self, config):
-        return [self.simulator.get_output_sizes(config)[0]] #Isn't this just the batch size? -> No
+        return [self.simulator.get_output_sizes(config)[0]]
 
     def __call__(self, parameters, config):
         assert len(parameters) == 1, "Batching requires models to have a single input vector!"

--- a/batcher.py
+++ b/batcher.py
@@ -2,6 +2,7 @@ import argparse
 import umbridge
 import threading
 import time
+import copy
 
 # Define a model that batches parameters per config before sending them to the simulator
 class Batcher(umbridge.Model):
@@ -48,7 +49,7 @@ class Batcher(umbridge.Model):
                             raise RuntimeError("Cannot pad an empty batch - no parameters available for shape inference")
 
                         while len(self.parameters) < self._batchsize:
-                            self.parameters.append(list(padding_vector))
+                            self.parameters.append(copy.deepcopy(padding_vector))
                         self._compute()
                         self.batchLock.notify_all()
                         break

--- a/batcher.py
+++ b/batcher.py
@@ -40,8 +40,15 @@ class Batcher(umbridge.Model):
                     if (self.is_full() or remaining_time <= 0):
                         # Pad parameters in case the batch is not full
                         print(f"The actual size of the parameters is {len(self.parameters)}")
+                        # Use the last parameter for padding to maintain valid input shapes/values
+                        if len(self.parameters) > 0:
+                            padding_vector = self.parameters[-1]
+                        else:
+                             # Fallback if batch is empty (shouldn't happen in current logic but safe)
+                            padding_vector = [0.01]
+
                         while len(self.parameters) < self._batchsize:
-                            self.parameters.append([0.01])
+                            self.parameters.append(padding_vector)
                         self._compute()
                         self.batchLock.notify_all()
                         break

--- a/batcher.py
+++ b/batcher.py
@@ -44,7 +44,7 @@ class Batcher(umbridge.Model):
                         if len(self.parameters) > 0:
                             padding_vector = self.parameters[-1]
                         else:
-                             # This should not happen since we always add a sample before waiting
+                            # This should not happen since we always add a sample before waiting
                             raise RuntimeError("Cannot pad an empty batch - no parameters available for shape inference")
 
                         while len(self.parameters) < self._batchsize:

--- a/batcher.py
+++ b/batcher.py
@@ -44,12 +44,8 @@ class Batcher(umbridge.Model):
                         if len(self.parameters) > 0:
                             padding_vector = self.parameters[-1]
                         else:
-                             # Empty batch at submission time indicates a logic error; fail fast.
-                            raise RuntimeError(
-                                "Attempted to submit an empty batch. "
-                                "This should not happen; ensure that at least one sample is added "
-                                "before waiting for results."
-                            )
+                             # This should not happen since we always add a sample before waiting
+                            raise RuntimeError("Cannot pad an empty batch - no parameters available for shape inference")
 
                         while len(self.parameters) < self._batchsize:
                             self.parameters.append(padding_vector)
@@ -117,12 +113,10 @@ class Batcher(umbridge.Model):
         self.lock = threading.Lock()
 
     def get_input_sizes(self, config):
-        #return [self.simulator.get_input_sizes(config)[0]] #Isn't this just the batch size? -> No
-        return 1
+        return [self.simulator.get_input_sizes(config)[0]] #Isn't this just the batch size? -> No
 
     def get_output_sizes(self, config):
-        #return [self.simulator.get_output_sizes(config)[0]] #Isn't this just the batch size? -> No
-        return 1
+        return [self.simulator.get_output_sizes(config)[0]] #Isn't this just the batch size? -> No
 
     def __call__(self, parameters, config):
         assert len(parameters) == 1, "Batching requires models to have a single input vector!"

--- a/batcher.py
+++ b/batcher.py
@@ -44,8 +44,12 @@ class Batcher(umbridge.Model):
                         if len(self.parameters) > 0:
                             padding_vector = self.parameters[-1]
                         else:
-                             # Fallback if batch is empty (shouldn't happen in current logic but safe)
-                            padding_vector = [0.01]
+                             # Empty batch at submission time indicates a logic error; fail fast.
+                            raise RuntimeError(
+                                "Attempted to submit an empty batch. "
+                                "This should not happen; ensure that at least one sample is added "
+                                "before waiting for results."
+                            )
 
                         while len(self.parameters) < self._batchsize:
                             self.parameters.append(padding_vector)

--- a/test_padding.py
+++ b/test_padding.py
@@ -2,8 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 import argparse
 import batcher
-import threading
-import time
+
 
 class TestPadding(unittest.TestCase):
     def test_padding_shape_mismatch(self):

--- a/test_padding.py
+++ b/test_padding.py
@@ -7,11 +7,10 @@ import time
 
 class TestPadding(unittest.TestCase):
     def test_padding_shape_mismatch(self):
-        # Scenario: Input vector has size 2. Batch size is 2.
-        # We submit 1 item. Timeout occurs.
-        # Code attempts to pad with [0.01] (size 1).
-        # This should result in a batch with mixed shapes [[0.1, 0.2], [0.01]]
-        # The simulator (mock) should receive this.
+        # Scenario: Input vector has size 2 and batch size is 2.
+        # We submit 1 item and let the timeout occur so the batch is completed via padding.
+        # The padding behavior is to reuse the last submitted parameter, producing [[0.1, 0.2], [0.1, 0.2]].
+        # The simulator (mock) should therefore receive a batch where all vectors have the same length.
         
         args = argparse.Namespace()
         args.url = "http://localhost:4242"

--- a/test_padding.py
+++ b/test_padding.py
@@ -7,8 +7,8 @@ class TestPadding(unittest.TestCase):
     def test_padding_shape_mismatch(self):
         # Scenario: Input vector has size 2. Batch size is 2.
         # We submit 1 item. Timeout occurs.
-        # The batcher should pad with the last item ([0.1, 0.2]) instead of [0.01].
-        # The simulator should receive a batch of size 2 with identical vectors.
+        # Verify that the batcher pads with the last submitted item ([0.1, 0.2])
+        # to ensure the simulator receives a valid, consistent batch.
         
         args = argparse.Namespace()
         args.url = "http://localhost:4242"
@@ -28,7 +28,7 @@ class TestPadding(unittest.TestCase):
             for i, p in enumerate(params):
                 if len(p) != first_len:
                     raise ValueError(f"Shape mismatch at index {i}: expected {first_len}, got {len(p)}")
-            return [[0.5]] * len(params)
+            return [0.5] * len(params)
             
         mock_sim.side_effect = check_input_shape
         

--- a/test_padding.py
+++ b/test_padding.py
@@ -35,22 +35,18 @@ class TestPadding(unittest.TestCase):
         b = batcher.Batcher(mock_sim, args)
         
         # Submit a vector of size 2
-        try:
-            # This should now succeed because padding will match the input vector [0.1, 0.2]
-            b([[0.1, 0.2]], {"order": "3"})
-            
-            # Verify that the simulator was called with a batch of size 2
-            # And that both elements are [0.1, 0.2] (the padded one matches the original)
-            mock_sim.assert_called_once()
-            call_args = mock_sim.call_args
-            submitted_params = call_args[0][0] # First arg is parameters
-            
-            self.assertEqual(len(submitted_params), 2, "Batch size should be padded to 2")
-            self.assertEqual(submitted_params[0], [0.1, 0.2], "First item mismatch")
-            self.assertEqual(submitted_params[1], [0.1, 0.2], "Padded item mismatch (should match last input)")
-            
-        except Exception as e:
-            self.fail(f"Test failed with unexpected error: {e}")
+        # This should now succeed because padding will match the input vector [0.1, 0.2]
+        b([[0.1, 0.2]], {"order": "3"})
+        
+        # Verify that the simulator was called with a batch of size 2
+        # And that both elements are [0.1, 0.2] (the padded one matches the original)
+        mock_sim.assert_called_once()
+        call_args = mock_sim.call_args
+        submitted_params = call_args[0][0] # First arg is parameters
+        
+        self.assertEqual(len(submitted_params), 2, "Batch size should be padded to 2")
+        self.assertEqual(submitted_params[0], [0.1, 0.2], "First item mismatch")
+        self.assertEqual(submitted_params[1], [0.1, 0.2], "Padded item mismatch (should match last input)")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_padding.py
+++ b/test_padding.py
@@ -3,13 +3,12 @@ from unittest.mock import MagicMock
 import argparse
 import batcher
 
-
 class TestPadding(unittest.TestCase):
     def test_padding_shape_mismatch(self):
-        # Scenario: Input vector has size 2 and batch size is 2.
-        # We submit 1 item and let the timeout occur so the batch is completed via padding.
-        # The padding behavior is to reuse the last submitted parameter, producing [[0.1, 0.2], [0.1, 0.2]].
-        # The simulator (mock) should therefore receive a batch where all vectors have the same length.
+        # Scenario: Input vector has size 2. Batch size is 2.
+        # We submit 1 item. Timeout occurs.
+        # The batcher should pad with the last item ([0.1, 0.2]) instead of [0.01].
+        # The simulator should receive a batch of size 2 with identical vectors.
         
         args = argparse.Namespace()
         args.url = "http://localhost:4242"
@@ -39,6 +38,17 @@ class TestPadding(unittest.TestCase):
         try:
             # This should now succeed because padding will match the input vector [0.1, 0.2]
             b([[0.1, 0.2]], {"order": "3"})
+            
+            # Verify that the simulator was called with a batch of size 2
+            # And that both elements are [0.1, 0.2] (the padded one matches the original)
+            mock_sim.assert_called_once()
+            call_args = mock_sim.call_args
+            submitted_params = call_args[0][0] # First arg is parameters
+            
+            self.assertEqual(len(submitted_params), 2, "Batch size should be padded to 2")
+            self.assertEqual(submitted_params[0], [0.1, 0.2], "First item mismatch")
+            self.assertEqual(submitted_params[1], [0.1, 0.2], "Padded item mismatch (should match last input)")
+            
         except Exception as e:
             self.fail(f"Test failed with unexpected error: {e}")
 

--- a/test_padding.py
+++ b/test_padding.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import MagicMock
+import argparse
+import batcher
+import threading
+import time
+
+class TestPadding(unittest.TestCase):
+    def test_padding_shape_mismatch(self):
+        # Scenario: Input vector has size 2. Batch size is 2.
+        # We submit 1 item. Timeout occurs.
+        # Code attempts to pad with [0.01] (size 1).
+        # This should result in a batch with mixed shapes [[0.1, 0.2], [0.01]]
+        # The simulator (mock) should receive this.
+        
+        args = argparse.Namespace()
+        args.url = "http://localhost:4242"
+        args.model = "test_model"
+        args.batchsize = 2
+        args.batchsize2 = 2
+        args.port = 4242
+        args.timeout = 0.1
+        
+        mock_sim = MagicMock()
+        mock_sim.supports_evaluate.return_value = True
+        
+        def check_input_shape(params, config):
+            # params should be a list of vectors
+            # All vectors should have the same length
+            first_len = len(params[0])
+            for i, p in enumerate(params):
+                if len(p) != first_len:
+                    raise ValueError(f"Shape mismatch at index {i}: expected {first_len}, got {len(p)}")
+            return [[0.5]] * len(params)
+            
+        mock_sim.side_effect = check_input_shape
+        
+        b = batcher.Batcher(mock_sim, args)
+        
+        # Submit a vector of size 2
+        try:
+            # This should now succeed because padding will match the input vector [0.1, 0.2]
+            b([[0.1, 0.2]], {"order": "3"})
+        except Exception as e:
+            self.fail(f"Test failed with unexpected error: {e}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR fixes the hardcoded padding issue where the batcher would pad with `[0.01]` regardless of the input vector shape.

### Changes
- Updated `batcher.py` to use the last submitted parameter for padding instead of a hardcoded default. This ensures correct input shapes and valid values for the simulator.
- Added `test_padding.py` to verify that inputs with non-scalar shapes are handled correctly without errors.

Fixes #5